### PR TITLE
Exposed emitter for getting events information

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "bluebird": "^3.4.5",
     "debug": "^2.2.0",
+    "eventemitter2": "^2.1.3",
     "jsonfile": "^2.2.3",
     "lodash": "^4.15.0",
     "request": "^2.69.0"


### PR DESCRIPTION
Using new event emitter library for exposing request information on webHook trigger.

```
var webHooks = new WebHooks({
    db: WEBHOOKS_DB,
    DEBUG: true
});

var emitter = webHooks.getEmitter();

emitter.on('*.success', function (shortname, statusCode, body) {
    log.info('Success on trigger webHook' + shortname + 'with status code', statusCode, 'and body', body);
});

emitter.on('*.failure', function (shortname, statusCode, body) {
    log.error('Error on trigger webHook' + shortname + 'with status code', statusCode, 'and body', body);
});
```

This makes possible checking if a webHook trigger was succesful or not getting request information such as status code or response body.

The format for the events is builded as `eventName.result`. The choosen library `eventemitter2` provides a lot of freedom for listening events. For example:

- `eventName.success`
- `eventName.failure`
- `eventName.*`
- `*.success`
- `*.*`