### PR TITLE
Url parameter interpolation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ webHooks.add('shortname2', 'http://127.0.0.1:9000/prova2/').then(function(){
 	console.log(err)
 });
 
+// add a webHook with url parameter interpolation
+webHooks.add('shortname3', 'http://127.0.0.1:9000/:id?search=:query').then(function(){
+	// done
+}).catch(function(err){
+	console.log(err)
+});
+
 // remove a single url attached to the given shortname
 // webHooks.remove('shortname3', 'http://127.0.0.1:9000/query/').catch(function(err){console.error(err);})
 
@@ -61,6 +68,9 @@ webHooks.add('shortname2', 'http://127.0.0.1:9000/prova2/').then(function(){
 // trigger a specific webHook
 webHooks.trigger('shortname1', {data: 123})
 webHooks.trigger('shortname2', {data: 123456}, {header: 'header'}) // payload will be sent as POST request with JSON body (Content-Type: application/json) and custom header
+
+// trigger a webhook with url parameter interpolation
+webHooks.trigger('shortname3', {data: 123456}, {header: 'header'}, {id: 123, query: 'xyz'})
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -106,17 +106,25 @@ function _setListeners (self) {
   // console.log(_functions[0] == _functions[2]);
 }
 
+function _interpolate (url, params) {
+  return _.reduce(params, function (currentUrl, value, key) {
+    return currentUrl.replace(new RegExp(':' + key, 'g'), value)
+  }, url)
+}
+
 function _getRequestFunction (self, url) {
   // return the function then called by the event listener.
-  var func = function (shortname, jsonData, headersData) { // argument required when eventEmitter.emit()
+  var func = function (shortname, jsonData, headersData, paramsData) { // argument required when eventEmitter.emit()
     var obj = {'Content-Type': 'application/json'}
     var headers = headersData ? _.merge(obj, headersData) : obj
+    var params = paramsData || {}
+    var resolvedUrl = _interpolate(url, params)
 
-    debug('POST request to:', url)
+    debug('POST request to:', resolvedUrl)
     // POST request to the instantiated URL with custom headers if provided
     request({
       method: 'POST',
-      uri: url,
+      uri: resolvedUrl,
       strictSSL: false,
       headers: headers,
       body: JSON.stringify(jsonData)
@@ -141,9 +149,9 @@ function _getRequestFunction (self, url) {
 
 // 'prototype' has improved performances, let's declare the methods
 
-WebHooks.prototype.trigger = function (shortname, jsonData, headersData) {
+WebHooks.prototype.trigger = function (shortname, jsonData, headersData, paramsData) {
   // trigger a webHook
-  this.emitter.emit(shortname, shortname, jsonData, headersData)
+  this.emitter.emit(shortname, shortname, jsonData, headersData, paramsData)
 }
 
 WebHooks.prototype.add = function (shortname, url) { // url is required

--- a/test/webhooks.js
+++ b/test/webhooks.js
@@ -182,9 +182,9 @@ function deleteHook1 (done) {
 
 describe('Tests >', function () {
   before(function (done) {
-        // Lets start our server
+    // Lets start our server
     server.listen(PORT, function () {
-            // Callback triggered when server is successfully listening. Hurray!
+      // Callback triggered when server is successfully listening. Hurray!
       debug('Server listening on: http://localhost:%s', PORT)
       done()
     })
@@ -323,6 +323,23 @@ describe('Tests >', function () {
       expect(OUTCOMES['/1/bbb']).to.have.property('body').equal('{}')
       done()
     }, 1000)
+  })
+
+  context('with url parameter interpolation', function () {
+    before(() => {
+      return webHooks.add('hook1', URI + '/:id/aaa')
+    })
+    it('should fire the webHook with url parameters', function (done) {
+      this.timeout(3000)
+      OUTCOMES = {}
+      webHooks.trigger('hook1', {}, {}, {
+        id: '123'
+      })
+      setTimeout(function () {
+        should.exist(OUTCOMES['/123/aaa'])
+        done()
+      }, 1000)
+    })
   })
 
   it('should fire the webHook with both custom body and headers', function (done) {


### PR DESCRIPTION
Allows you to define webhooks like this:

```
webHooks.add('hook', URI + '/:id/abc')
```

and trigger like this:

```
webHooks.trigger('hook', {}, {}, { id: '123' })
```